### PR TITLE
Updated event link

### DIFF
--- a/_includes/_events.html
+++ b/_includes/_events.html
@@ -10,7 +10,7 @@
       <p>
       We have talks every fourth Wednesday; our next event is July 27th, 2016 at 7pm. <br />Details will be announced soon.
       </p>
-      <p><a href="http://www.meetup.com/NY-Haskell/" class="mu-rsvp-btn">RSVP</a></p>
+      <p><a href="http://www.meetup.com/NY-Haskell/events/234761999/" class="mu-rsvp-btn">RSVP</a></p>
       <p></p>
       <p></p>
     </div><!-- col-lg -->


### PR DESCRIPTION
Changed upcoming event link to: http://www.meetup.com/NY-Haskell/events/234761999/
