### PR TITLE
Fixes pop-up video titles readability. Fixes video width in video modal.

### DIFF
--- a/_includes/_videos.html
+++ b/_includes/_videos.html
@@ -37,7 +37,7 @@
               </div>
               <div class="modal-body">
                 <p>
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/{{video.youtubeId}}" frameborder="0" allowfullscreen></iframe>
+                <iframe width="100%" height="315" src="https://www.youtube.com/embed/{{video.youtubeId}}" frameborder="0" allowfullscreen></iframe>
                 </p>
                 <p>
                   <b>{{video.title}}</b>, by {{video.speaker.name}}
@@ -72,3 +72,4 @@
     </div><!-- /row -->
   </div><!-- /container -->
   </div><!-- /container -->
+

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -518,13 +518,15 @@ a:after {
 	font-weight: 700;
 	text-align: left;
 	letter-spacing: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 	
 }
 
 .grid figcaption a {
 	text-align: left;
 	padding: 5px 10px;
-	margin-left: 20px;
 	display: inline-block;
 	/*background: #2f2f2f;*/
 	color: #fff;
@@ -582,7 +584,7 @@ a:after {
 	position: absolute;
 	top:10px;
 	bottom: 10px;
-	right: 30px;
+  width: 90%;
 }
 
 


### PR DESCRIPTION
Hello NY Haskell.

This fixes the pop-up video titles from being truncated from the left. It moves them over and adds a nice ellipsis effect. This change is responsive.

To see the changes locally, you will need to edit `_config.yml` to point to your local Jekyll build.

```yml
# google_analytics:
url: http://localhost:4000 # <--
```

![nyhaskell_title_before](https://cloud.githubusercontent.com/assets/1661343/20645451/d0c76520-b42c-11e6-8410-87d22d67f35c.gif)
![nyhaskell_title_after](https://cloud.githubusercontent.com/assets/1661343/20645453/d84a73e6-b42c-11e6-93ab-c92b01576296.gif)
![selection_165](https://cloud.githubusercontent.com/assets/1661343/20645483/e51ac1c4-b42d-11e6-98ae-fbbc29597031.png)
![screenshot_2016-11-26-22-44-55](https://cloud.githubusercontent.com/assets/1661343/20645468/5ffd1dc0-b42d-11e6-908c-ff43d381e303.png)

---

This also fixes the responsiveness of the video width found in the video modal. On smaller screens, the video extends past the modal window. 

![screenshot_2016-11-26-22-42-38](https://cloud.githubusercontent.com/assets/1661343/20645473/891af13c-b42d-11e6-9d9b-d6259a86ad6d.png)


Tested on:
* Firefox Version 48.0.2
* Firefox for Android Version 50.0
* Chrome Version 54.0.2840.100
* Chrome for Android Version 54.0.2840.85

Side note: the `assets/css/main.css` file contains tabs and I inserted my changes with two spaces which is the reason for the indentation mismatch. I left the tabs alone to avoid any confusion as to what changes I made. They do align in my editor, however.

Cheers! :+1: 